### PR TITLE
Branch fix repeat time

### DIFF
--- a/src/main/java/seedu/duke/command/RepeatCommand.java
+++ b/src/main/java/seedu/duke/command/RepeatCommand.java
@@ -3,7 +3,12 @@ package seedu.duke.command;
 import seedu.duke.data.UserData;
 import seedu.duke.event.Event;
 import seedu.duke.event.EventList;
-import seedu.duke.exception.*;
+import seedu.duke.exception.DukeException;
+import seedu.duke.exception.InvalidTimeUnitException;
+import seedu.duke.exception.MissingDeadlineRepeatException;
+import seedu.duke.exception.MissingRepeatListException;
+import seedu.duke.exception.WrongNumberFormatException;
+import seedu.duke.exception.WrongNumberOfArgumentsException;
 import seedu.duke.storage.Storage;
 import seedu.duke.ui.Ui;
 

--- a/src/main/java/seedu/duke/command/RepeatCommand.java
+++ b/src/main/java/seedu/duke/command/RepeatCommand.java
@@ -3,11 +3,7 @@ package seedu.duke.command;
 import seedu.duke.data.UserData;
 import seedu.duke.event.Event;
 import seedu.duke.event.EventList;
-import seedu.duke.exception.DukeException;
-import seedu.duke.exception.InvalidTimeUnitException;
-import seedu.duke.exception.MissingDeadlineRepeatException;
-import seedu.duke.exception.WrongNumberFormatException;
-import seedu.duke.exception.WrongNumberOfArgumentsException;
+import seedu.duke.exception.*;
 import seedu.duke.storage.Storage;
 import seedu.duke.ui.Ui;
 
@@ -119,6 +115,9 @@ public class RepeatCommand extends Command {
         EventList eventList = data.getEventList(words[0]);
         int index = Integer.parseInt(words[1]) - 1;
         Event repeatEvent = eventList.getEventByIndex(index);
+        if (repeatEvent.getRepeatEventList() == null) {
+            throw new MissingRepeatListException();
+        }
         ui.printRepeatList(repeatEvent);
     }
 

--- a/src/main/java/seedu/duke/exception/MissingRepeatListException.java
+++ b/src/main/java/seedu/duke/exception/MissingRepeatListException.java
@@ -1,0 +1,9 @@
+package seedu.duke.exception;
+
+public class MissingRepeatListException extends DukeException {
+
+    public MissingRepeatListException() {
+        super("This event has not been repeated currently");
+    }
+
+}

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -59,7 +59,7 @@ public class Ui {
         ArrayList<Event> repeatEventList = event.getRepeatEventList();
         for (Event e : repeatEventList) {
             System.out.printf("%s ", e.getDate().format(DateTimeFormatter.ofPattern("dd MMM yyyy")));
-            if (e.getTime() != null){
+            if (e.getTime() != null) {
                 System.out.printf("%s ", e.getTime().format(DateTimeFormatter.ofPattern("K:mm a")));
             }
             System.out.printf("[%s]", e.getStatus());

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -59,7 +59,9 @@ public class Ui {
         ArrayList<Event> repeatEventList = event.getRepeatEventList();
         for (Event e : repeatEventList) {
             System.out.printf("%s ", e.getDate().format(DateTimeFormatter.ofPattern("dd MMM yyyy")));
-            System.out.printf("%s ", e.getTime().format(DateTimeFormatter.ofPattern("K:mm a")));
+            if (e.getTime() != null){
+                System.out.printf("%s ", e.getTime().format(DateTimeFormatter.ofPattern("K:mm a")));
+            }
             System.out.printf("[%s]", e.getStatus());
             System.out.println();
         }

--- a/src/test/java/seedu/duke/command/RepeatCommandTest.java
+++ b/src/test/java/seedu/duke/command/RepeatCommandTest.java
@@ -8,6 +8,7 @@ import seedu.duke.exception.InvalidIndexException;
 import seedu.duke.exception.InvalidListException;
 import seedu.duke.exception.InvalidTimeUnitException;
 import seedu.duke.exception.MissingDeadlineRepeatException;
+import seedu.duke.exception.MissingRepeatListException;
 import seedu.duke.exception.WrongNumberFormatException;
 import seedu.duke.exception.WrongNumberOfArgumentsException;
 import seedu.duke.storage.Storage;
@@ -18,6 +19,8 @@ import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class RepeatCommandTest {
 
@@ -39,7 +42,14 @@ class RepeatCommandTest {
         addCommand = new AddCommand(personalInput);
         addCommand.execute(data, ui, storage);
 
-        //Add Zoom event to data
+        personalInput = "personal hello; 29/02/2020";
+        addCommand = new AddCommand(personalInput);
+        addCommand.execute(data, ui, storage);
+
+        personalInput = "personal leap ahead; 31/01/2019";
+        addCommand = new AddCommand(personalInput);
+        addCommand.execute(data, ui, storage);
+
         // Add zoom event to data
         String zoomInput = "zoom Math class; zoom.com; 09/10/2000; 1300";
         addCommand = new AddCommand(zoomInput);
@@ -84,6 +94,110 @@ class RepeatCommandTest {
                         + "09 Feb 2001 1:00 PM [✕]" + System.lineSeparator()
                         + "_________________________________" + System.lineSeparator(),
                 outputStreamCaptor.toString());
+    }
+
+    @Test
+    void repeat_personalEventMonthlyNoTime_personalEventRepeatedMonthly() throws DukeException {
+
+
+        // Create Repeat Command
+        String inputString = "personal 3 monthly 4";
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        Command repeatCommand = RepeatCommand.parse(inputString);
+        repeatCommand.execute(data, ui, storage);
+        assertEquals("[P][✕] hello on 2020-02-29" + System.lineSeparator()
+                        + "is now repeating monthly for 4 times." + System.lineSeparator()
+                        + "_________________________________" + System.lineSeparator(),
+                outputStreamCaptor.toString());
+
+        //check the dates reported and erase previous output
+        inputString = "personal 3";
+        outputStreamCaptor.reset();
+
+        repeatCommand = RepeatCommand.parse(inputString);
+        repeatCommand.execute(data, ui, storage);
+
+        assertEquals("[P][✕] hello on 2020-02-29 is also on:"
+                        + System.lineSeparator()
+                        + "29 Mar 2020 [✕]" + System.lineSeparator()
+                        + "29 Apr 2020 [✕]" + System.lineSeparator()
+                        + "29 May 2020 [✕]" + System.lineSeparator()
+                        + "29 Jun 2020 [✕]" + System.lineSeparator()
+                        + "_________________________________" + System.lineSeparator(),
+                outputStreamCaptor.toString());
+    }
+
+    @Test
+    void repeat_personalEventMonthlyLeapYearFinalDay_personalEventRepeatedMonthly() throws DukeException {
+
+
+        // Create Repeat Command
+        String inputString = "personal 4 monthly 24";
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        Command repeatCommand = RepeatCommand.parse(inputString);
+        repeatCommand.execute(data, ui, storage);
+        assertEquals("[P][✕] leap ahead on 2019-01-31" + System.lineSeparator()
+                        + "is now repeating monthly for 24 times." + System.lineSeparator()
+                        + "_________________________________" + System.lineSeparator(),
+                outputStreamCaptor.toString());
+
+        //check the dates reported and erase previous output
+        inputString = "personal 4";
+        outputStreamCaptor.reset();
+
+        repeatCommand = RepeatCommand.parse(inputString);
+        repeatCommand.execute(data, ui, storage);
+
+        assertEquals("[P][✕] leap ahead on 2019-01-31 is also on:"
+                        + System.lineSeparator()
+                        + "28 Feb 2019 [✕]" + System.lineSeparator()
+                        + "31 Mar 2019 [✕]" + System.lineSeparator()
+                        + "30 Apr 2019 [✕]" + System.lineSeparator()
+                        + "31 May 2019 [✕]" + System.lineSeparator()
+                        + "30 Jun 2019 [✕]" + System.lineSeparator()
+                        + "31 Jul 2019 [✕]" + System.lineSeparator()
+                        + "31 Aug 2019 [✕]" + System.lineSeparator()
+                        + "30 Sep 2019 [✕]" + System.lineSeparator()
+                        + "31 Oct 2019 [✕]" + System.lineSeparator()
+                        + "30 Nov 2019 [✕]" + System.lineSeparator()
+                        + "31 Dec 2019 [✕]" + System.lineSeparator()
+                        + "31 Jan 2020 [✕]" + System.lineSeparator()
+                        + "29 Feb 2020 [✕]" + System.lineSeparator()
+                        + "31 Mar 2020 [✕]" + System.lineSeparator()
+                        + "30 Apr 2020 [✕]" + System.lineSeparator()
+                        + "31 May 2020 [✕]" + System.lineSeparator()
+                        + "30 Jun 2020 [✕]" + System.lineSeparator()
+                        + "31 Jul 2020 [✕]" + System.lineSeparator()
+                        + "31 Aug 2020 [✕]" + System.lineSeparator()
+                        + "30 Sep 2020 [✕]" + System.lineSeparator()
+                        + "31 Oct 2020 [✕]" + System.lineSeparator()
+                        + "30 Nov 2020 [✕]" + System.lineSeparator()
+                        + "31 Dec 2020 [✕]" + System.lineSeparator()
+                        + "31 Jan 2021 [✕]" + System.lineSeparator()
+                        + "_________________________________" + System.lineSeparator(),
+                outputStreamCaptor.toString());
+    }
+
+    @Test
+    void repeat_personalPrintRepeatNoExist_MissingRepeatListExceptionThrown() throws DukeException {
+
+
+        try {
+            // Create Repeat Command
+            String inputString = "personal 4";
+            System.setOut(new PrintStream(outputStreamCaptor));
+
+            Command repeatCommand = RepeatCommand.parse(inputString);
+            repeatCommand.execute(data, ui, storage);
+            fail("This command should have thrown an exception");
+        } catch (MissingRepeatListException e) {
+            assertTrue(true);
+        } catch (Exception e) {
+            fail("The wrong exception type was thrown");
+        }
+
     }
 
     @Test


### PR DESCRIPTION
Fixes #166, Fixes #177, Fixes #198, Fixes #202, Fixes #207 

To fix the problem, the ui print repeat list command will not attempt to print out timing information if there is no time information inside the event.
The code will throw an exception if repeat information is requested on an event that has not been repeated
Additional Junit testing added for cases of repeating events lying on 31 Jan 2019 for 24 months and also tests to see if repeat command can repeat events with no time and display the repeated events properly.