### PR TITLE
Branch repeat date print

### DIFF
--- a/src/main/java/seedu/duke/event/Event.java
+++ b/src/main/java/seedu/duke/event/Event.java
@@ -148,7 +148,7 @@ public abstract class Event implements Cloneable {
     }
 
     public String toCalendarString() {
-        return String.format("%s | ", time.format(DateTimeFormatter.ofPattern("K:mm a")))
+        return String.format("%s | ", time.format(DateTimeFormatter.ofPattern("h:mm a")))
                 + String.format("%s | ", getStatus())
                 + String.format("%s ", getDescription());
     }

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -57,9 +57,9 @@ public class Ui {
         int index = 1;
         for (Event e : repeatEventList) {
             System.out.print("    " + index + ". ");
-            System.out.printf("%s ", e.getDate().format(DateTimeFormatter.ofPattern("dd MMM yyyy")));
+            System.out.printf("%s ", e.getDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
             if (e.getTime() != null) {
-                System.out.printf("%s ", e.getTime().format(DateTimeFormatter.ofPattern("K:mm a")));
+                System.out.printf("%s ", e.getTime().format(DateTimeFormatter.ofPattern("HH:mm")));
             }
             System.out.printf("[%s]", e.getStatus());
             System.out.println();

--- a/src/test/java/seedu/duke/command/RepeatCommandTest.java
+++ b/src/test/java/seedu/duke/command/RepeatCommandTest.java
@@ -87,10 +87,10 @@ class RepeatCommandTest {
 
         assertEquals("[P][X] party on 2000-10-09, 13:00 is also on:"
                         + System.lineSeparator()
-                        + "    1. 09 Nov 2000 1:00 PM [X]" + System.lineSeparator()
-                        + "    2. 09 Dec 2000 1:00 PM [X]" + System.lineSeparator()
-                        + "    3. 09 Jan 2001 1:00 PM [X]" + System.lineSeparator()
-                        + "    4. 09 Feb 2001 1:00 PM [X]" + System.lineSeparator(),
+                        + "    1. 2000-11-09 13:00 [X]" + System.lineSeparator()
+                        + "    2. 2000-12-09 13:00 [X]" + System.lineSeparator()
+                        + "    3. 2001-01-09 13:00 [X]" + System.lineSeparator()
+                        + "    4. 2001-02-09 13:00 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
     }
 
@@ -117,10 +117,10 @@ class RepeatCommandTest {
 
         assertEquals("[P][X] hello on 2020-02-29 is also on:"
                         + System.lineSeparator()
-                        + "    1. 29 Mar 2020 [X]" + System.lineSeparator()
-                        + "    2. 29 Apr 2020 [X]" + System.lineSeparator()
-                        + "    3. 29 May 2020 [X]" + System.lineSeparator()
-                        + "    4. 29 Jun 2020 [X]" + System.lineSeparator(),
+                        + "    1. 2020-03-29 [X]" + System.lineSeparator()
+                        + "    2. 2020-04-29 [X]" + System.lineSeparator()
+                        + "    3. 2020-05-29 [X]" + System.lineSeparator()
+                        + "    4. 2020-06-29 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
     }
 
@@ -147,30 +147,30 @@ class RepeatCommandTest {
 
         assertEquals("[P][X] leap ahead on 2019-01-31 is also on:"
                         + System.lineSeparator()
-                        + "    1. 28 Feb 2019 [X]" + System.lineSeparator()
-                        + "    2. 31 Mar 2019 [X]" + System.lineSeparator()
-                        + "    3. 30 Apr 2019 [X]" + System.lineSeparator()
-                        + "    4. 31 May 2019 [X]" + System.lineSeparator()
-                        + "    5. 30 Jun 2019 [X]" + System.lineSeparator()
-                        + "    6. 31 Jul 2019 [X]" + System.lineSeparator()
-                        + "    7. 31 Aug 2019 [X]" + System.lineSeparator()
-                        + "    8. 30 Sep 2019 [X]" + System.lineSeparator()
-                        + "    9. 31 Oct 2019 [X]" + System.lineSeparator()
-                        + "    10. 30 Nov 2019 [X]" + System.lineSeparator()
-                        + "    11. 31 Dec 2019 [X]" + System.lineSeparator()
-                        + "    12. 31 Jan 2020 [X]" + System.lineSeparator()
-                        + "    13. 29 Feb 2020 [X]" + System.lineSeparator()
-                        + "    14. 31 Mar 2020 [X]" + System.lineSeparator()
-                        + "    15. 30 Apr 2020 [X]" + System.lineSeparator()
-                        + "    16. 31 May 2020 [X]" + System.lineSeparator()
-                        + "    17. 30 Jun 2020 [X]" + System.lineSeparator()
-                        + "    18. 31 Jul 2020 [X]" + System.lineSeparator()
-                        + "    19. 31 Aug 2020 [X]" + System.lineSeparator()
-                        + "    20. 30 Sep 2020 [X]" + System.lineSeparator()
-                        + "    21. 31 Oct 2020 [X]" + System.lineSeparator()
-                        + "    22. 30 Nov 2020 [X]" + System.lineSeparator()
-                        + "    23. 31 Dec 2020 [X]" + System.lineSeparator()
-                        + "    24. 31 Jan 2021 [X]" + System.lineSeparator(),
+                        + "    1. 2019-02-28 [X]" + System.lineSeparator()
+                        + "    2. 2019-03-31 [X]" + System.lineSeparator()
+                        + "    3. 2019-04-30 [X]" + System.lineSeparator()
+                        + "    4. 2019-05-31 [X]" + System.lineSeparator()
+                        + "    5. 2019-06-30 [X]" + System.lineSeparator()
+                        + "    6. 2019-07-31 [X]" + System.lineSeparator()
+                        + "    7. 2019-08-31 [X]" + System.lineSeparator()
+                        + "    8. 2019-09-30 [X]" + System.lineSeparator()
+                        + "    9. 2019-10-31 [X]" + System.lineSeparator()
+                        + "    10. 2019-11-30 [X]" + System.lineSeparator()
+                        + "    11. 2019-12-31 [X]" + System.lineSeparator()
+                        + "    12. 2020-01-31 [X]" + System.lineSeparator()
+                        + "    13. 2020-02-29 [X]" + System.lineSeparator()
+                        + "    14. 2020-03-31 [X]" + System.lineSeparator()
+                        + "    15. 2020-04-30 [X]" + System.lineSeparator()
+                        + "    16. 2020-05-31 [X]" + System.lineSeparator()
+                        + "    17. 2020-06-30 [X]" + System.lineSeparator()
+                        + "    18. 2020-07-31 [X]" + System.lineSeparator()
+                        + "    19. 2020-08-31 [X]" + System.lineSeparator()
+                        + "    20. 2020-09-30 [X]" + System.lineSeparator()
+                        + "    21. 2020-10-31 [X]" + System.lineSeparator()
+                        + "    22. 2020-11-30 [X]" + System.lineSeparator()
+                        + "    23. 2020-12-31 [X]" + System.lineSeparator()
+                        + "    24. 2021-01-31 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
     }
 
@@ -215,9 +215,9 @@ class RepeatCommandTest {
 
         assertEquals("[Z][X] Math class, Link: zoom.com on 2000-10-09, 13:00 is also on:"
                         + System.lineSeparator()
-                        + "    1. 16 Oct 2000 1:00 PM [X]" + System.lineSeparator()
-                        + "    2. 23 Oct 2000 1:00 PM [X]" + System.lineSeparator()
-                        + "    3. 30 Oct 2000 1:00 PM [X]" + System.lineSeparator(),
+                        + "    1. 2000-10-16 13:00 [X]" + System.lineSeparator()
+                        + "    2. 2000-10-23 13:00 [X]" + System.lineSeparator()
+                        + "    3. 2000-10-30 13:00 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
 
     }
@@ -245,9 +245,9 @@ class RepeatCommandTest {
 
         assertEquals("[T][X] Science class, Location: S17 on 2000-10-17, 15:00 is also on:"
                         + System.lineSeparator()
-                        + "    1. 18 Oct 2000 3:00 PM [X]" + System.lineSeparator()
-                        + "    2. 19 Oct 2000 3:00 PM [X]" + System.lineSeparator()
-                        + "    3. 20 Oct 2000 3:00 PM [X]" + System.lineSeparator(),
+                        + "    1. 2000-10-18 15:00 [X]" + System.lineSeparator()
+                        + "    2. 2000-10-19 15:00 [X]" + System.lineSeparator()
+                        + "    3. 2000-10-20 15:00 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
     }
 
@@ -285,8 +285,8 @@ class RepeatCommandTest {
 
         assertEquals("[P][X] party on 2000-10-09, 13:00 is also on:"
                         + System.lineSeparator()
-                        + "    1. 09 Nov 2000 1:00 PM [X]" + System.lineSeparator()
-                        + "    2. 09 Dec 2000 1:00 PM [X]" + System.lineSeparator(),
+                        + "    1. 2000-11-09 13:00 [X]" + System.lineSeparator()
+                        + "    2. 2000-12-09 13:00 [X]" + System.lineSeparator(),
                 outputStreamCaptor.toString());
 
 

--- a/src/test/java/seedu/duke/storage/StorageTest.java
+++ b/src/test/java/seedu/duke/storage/StorageTest.java
@@ -54,10 +54,10 @@ class StorageTest {
         assertEquals("The file has successfully been loaded!" + System.lineSeparator()
                         + "Here is a list of your Personal events:" + System.lineSeparator()
                         + "1. [P][X] stuff on 2010-01-01, 12:00 is also on:" + System.lineSeparator()
-                        + "    1. 08 Jan 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    2. 15 Jan 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    3. 22 Jan 2010 0:00 PM [O]" + System.lineSeparator()
-                        + "    4. 29 Jan 2010 0:00 PM [X]" + System.lineSeparator()
+                        + "    1. 2010-01-08 12:00 [X]" + System.lineSeparator()
+                        + "    2. 2010-01-15 12:00 [X]" + System.lineSeparator()
+                        + "    3. 2010-01-22 12:00 [O]" + System.lineSeparator()
+                        + "    4. 2010-01-29 12:00 [X]" + System.lineSeparator()
                         + "2. [P][O] birthday celebration on 2010-01-01, 12:00" + System.lineSeparator()
                         + "3. [P][X] others" + System.lineSeparator(),
                 outputStreamCaptor.toString());
@@ -71,10 +71,10 @@ class StorageTest {
         assertEquals("Here is a list of your Zoom events:" + System.lineSeparator()
                         + "1. [Z][X] math, Link: www.zoom.com/blah on 2010-01-01, 12:00 is also on:"
                         + System.lineSeparator()
-                        + "    1. 02 Jan 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    2. 03 Jan 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    3. 04 Jan 2010 0:00 PM [O]" + System.lineSeparator()
-                        + "    4. 05 Jan 2010 0:00 PM [X]" + System.lineSeparator()
+                        + "    1. 2010-01-02 12:00 [X]" + System.lineSeparator()
+                        + "    2. 2010-01-03 12:00 [X]" + System.lineSeparator()
+                        + "    3. 2010-01-04 12:00 [O]" + System.lineSeparator()
+                        + "    4. 2010-01-05 12:00 [X]" + System.lineSeparator()
                         + "2. [Z][O] computing, Link: www.zoom.com/hello on 2010-01-01, 12:00" + System.lineSeparator(),
                 outputStreamCaptor.toString());
 
@@ -86,10 +86,10 @@ class StorageTest {
 
         assertEquals("Here is a list of your Timetable events:" + System.lineSeparator()
                         + "1. [T][X] math, Location: S17 on 2010-01-01, 12:00 is also on:" + System.lineSeparator()
-                        + "    1. 01 Feb 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    2. 01 Mar 2010 0:00 PM [X]" + System.lineSeparator()
-                        + "    3. 01 Apr 2010 0:00 PM [O]" + System.lineSeparator()
-                        + "    4. 01 May 2010 0:00 PM [X]" + System.lineSeparator()
+                        + "    1. 2010-02-01 12:00 [X]" + System.lineSeparator()
+                        + "    2. 2010-03-01 12:00 [X]" + System.lineSeparator()
+                        + "    3. 2010-04-01 12:00 [O]" + System.lineSeparator()
+                        + "    4. 2010-05-01 12:00 [X]" + System.lineSeparator()
                         + "2. [T][O] computing, Location: COM2 on 2010-01-01, 12:00" + System.lineSeparator(),
                 outputStreamCaptor.toString());
 


### PR DESCRIPTION
Changed the format of all date printouts for repeat to follow the standard `yyyy-MM-dd hh:ss` format. Time now prints in 24 hour format